### PR TITLE
Add support for alias timezone names based on IANA backward compatibility

### DIFF
--- a/packages/timezone-data/src/data.ts
+++ b/packages/timezone-data/src/data.ts
@@ -1,0 +1,319 @@
+export const timezoneData: {name: string; label: string}[] = [
+    {
+        name: 'Pacific/Pago_Pago',
+        label: 'Midway Island, Samoa'
+    },
+    {
+        name: 'Pacific/Honolulu',
+        label: 'Hawaii'
+    },
+    {
+        name: 'America/Anchorage',
+        label: 'Alaska'
+    },
+    {
+        name: 'America/Tijuana',
+        label: 'Chihuahua, La Paz, Mazatlan'
+    },
+    {
+        name: 'America/Los_Angeles',
+        label: 'Pacific Time (US & Canada); Tijuana'
+    },
+    {
+        name: 'America/Phoenix',
+        label: 'Arizona'
+    },
+    {
+        name: 'America/Denver',
+        label: 'Mountain Time (US & Canada)'
+    },
+    {
+        name: 'America/Costa_Rica',
+        label: 'Central America'
+    },
+    {
+        name: 'America/Chicago',
+        label: 'Central Time (US & Canada)'
+    },
+    {
+        name: 'America/Mexico_City',
+        label: 'Guadalajara, Mexico City, Monterrey'
+    },
+    {
+        name: 'America/Regina',
+        label: 'Saskatchewan'
+    },
+    {
+        name: 'America/Bogota',
+        label: 'Bogota, Lima, Quito'
+    },
+    {
+        name: 'America/New_York',
+        label: 'Eastern Time (US & Canada)'
+    },
+    {
+        name: 'America/Fort_Wayne',
+        label: 'Indiana (East)'
+    },
+    {
+        name: 'America/Caracas',
+        label: 'Caracas, La Paz'
+    },
+    {
+        name: 'America/Halifax',
+        label: 'Atlantic Time (Canada); Greenland'
+    },
+    {
+        name: 'America/Santiago',
+        label: 'Santiago'
+    },
+    {
+        name: 'America/St_Johns',
+        label: 'Newfoundland'
+    },
+    {
+        name: 'America/Argentina/Buenos_Aires',
+        label: 'Buenos Aires, Brasilia, Georgetown'
+    },
+    {
+        name: 'America/Noronha',
+        label: 'Fernando de Noronha'
+    },
+    {
+        name: 'Atlantic/Azores',
+        label: 'Azores'
+    },
+    {
+        name: 'Atlantic/Cape_Verde',
+        label: 'Cape Verde Is.'
+    },
+    {
+        name: 'Etc/UTC',
+        label: 'UTC'
+    },
+    {
+        name: 'Africa/Casablanca',
+        label: 'Casablanca, Monrovia'
+    },
+    {
+        name: 'Europe/Dublin',
+        label: 'Dublin, Edinburgh, London'
+    },
+    {
+        name: 'Europe/Amsterdam',
+        label: ' Amsterdam, Berlin, Rome, Stockholm, Vienna'
+    },
+    {
+        name: 'Europe/Prague',
+        label: 'Belgrade, Bratislava, Budapest, Prague'
+    },
+    {
+        name: 'Europe/Paris',
+        label: 'Brussels, Copenhagen, Madrid, Paris'
+    },
+    {
+        name: 'Europe/Warsaw',
+        label: 'Sarajevo, Skopje, Warsaw, Zagreb'
+    },
+    {
+        name: 'Africa/Lagos',
+        label: 'West Central Africa'
+    },
+    {
+        name: 'Europe/Athens',
+        label: 'Athens, Beirut, Bucharest'
+    },
+    {
+        name: 'Africa/Cairo',
+        label: 'Cairo, Egypt'
+    },
+    {
+        name: 'Africa/Maputo',
+        label: 'Harare'
+    },
+    {
+        name: 'Europe/Kiev', // Changing name to 'Europe/Kiev', and keeping the UI with Kyiv. Change this once we are passed the moment lib update.
+        label: 'Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius'
+    },
+    {
+        name: 'Asia/Jerusalem',
+        label: 'Jerusalem'
+    },
+    {
+        name: 'Africa/Johannesburg',
+        label: 'Pretoria'
+    },
+    {
+        name: 'Asia/Baghdad',
+        label: 'Baghdad'
+    },
+    {
+        name: 'Asia/Riyadh',
+        label: 'Kuwait, Nairobi, Riyadh'
+    },
+    {
+        name: 'Europe/Istanbul',
+        label: 'Istanbul, Ankara'
+    },
+    {
+        name: 'Europe/Moscow',
+        label: 'Moscow, St. Petersburg, Volgograd'
+    },
+    {
+        name: 'Asia/Tehran',
+        label: 'Tehran'
+    },
+    {
+        name: 'Asia/Dubai',
+        label: 'Abu Dhabi, Muscat'
+    },
+    {
+        name: 'Asia/Baku',
+        label: 'Baku, Tbilisi, Yerevan'
+    },
+    {
+        name: 'Asia/Kabul',
+        label: 'Kabul'
+    },
+    {
+        name: 'Asia/Karachi',
+        label: 'Islamabad, Karachi, Tashkent'
+    },
+    {
+        name: 'Asia/Yekaterinburg',
+        label: 'Yekaterinburg'
+    },
+    {
+        name: 'Asia/Kolkata',
+        label: 'Chennai, Kolkata, Mumbai, New Delhi'
+    },
+    {
+        name: 'Asia/Kathmandu',
+        label: 'Katmandu'
+    },
+    {
+        name: 'Asia/Almaty',
+        label: 'Almaty, Novosibirsk'
+    },
+    {
+        name: 'Asia/Dhaka',
+        label: 'Astana, Dhaka, Sri Jayawardenepura'
+    },
+    {
+        name: 'Asia/Rangoon',
+        label: 'Rangoon'
+    },
+    {
+        name: 'Asia/Bangkok',
+        label: 'Bangkok, Hanoi, Jakarta'
+    },
+    {
+        name: 'Asia/Krasnoyarsk',
+        label: 'Krasnoyarsk'
+    },
+    {
+        name: 'Asia/Hong_Kong',
+        label: 'Beijing, Chongqing, Hong Kong, Urumqi'
+    },
+    {
+        name: 'Asia/Irkutsk',
+        label: 'Irkutsk, Ulaan Bataar'
+    },
+    {
+        name: 'Asia/Singapore',
+        label: 'Kuala Lumpur, Perth, Singapore, Taipei'
+    },
+    {
+        name: 'Asia/Tokyo',
+        label: 'Osaka, Sapporo, Tokyo'
+    },
+    {
+        name: 'Asia/Seoul',
+        label: 'Seoul'
+    },
+    {
+        name: 'Asia/Yakutsk',
+        label: 'Yakutsk'
+    },
+    {
+        name: 'Australia/Adelaide',
+        label: 'Adelaide'
+    },
+    {
+        name: 'Australia/Darwin',
+        label: 'Darwin'
+    },
+    {
+        name: 'Australia/Brisbane',
+        label: 'Brisbane, Guam, Port Moresby'
+    },
+    {
+        name: 'Australia/Sydney',
+        label: 'Canberra, Hobart, Melbourne, Sydney, Vladivostok'
+    },
+    {
+        name: 'Asia/Magadan',
+        label: 'Magadan, Soloman Is., New Caledonia'
+    },
+    {
+        name: 'Pacific/Auckland',
+        label: 'Auckland, Wellington'
+    },
+    {
+        name: 'Pacific/Fiji',
+        label: 'Fiji, Kamchatka, Marshall Is.'
+    },
+    {
+        name: 'Pacific/Kwajalein',
+        label: 'International Date Line West'
+    }
+];
+
+export const aliasTimezones = {
+    'Pacific/Samoa': 'Pacific/Pago_Pago',
+    'Pacific/Midway': 'Pacific/Pago_Pago',
+    'Pacific/Johnston': 'Pacific/Honolulu',
+    'America/Tijuana': 'America/Los_Angeles',
+    'America/Creston': 'America/Phoenix',
+    'America/Shiprock': 'America/Denver',
+    'America/Indiana/Indianapolis': 'America/Fort_Wayne',
+    'America/Buenos_Aires': 'America/Argentina/Buenos_Aires',
+    'Europe/Brussels': 'Europe/Amsterdam',
+    'Europe/Bratislava': 'Europe/Prague',
+    'Europe/Monaco': 'Europe/Paris',
+    'Africa/Bangui': 'Africa/Lagos',
+    'Africa/Brazzaville': 'Africa/Lagos',
+    'Africa/Douala': 'Africa/Lagos',
+    'Africa/Kinshasa': 'Africa/Lagos',
+    'Africa/Libreville': 'Africa/Lagos',
+    'Africa/Luanda': 'Africa/Lagos',
+    'Africa/Malabo': 'Africa/Lagos',
+    'Africa/Niamey': 'Africa/Lagos',
+    'Africa/Porto-Novo': 'Africa/Lagos',
+    'Africa/Blantyre': 'Africa/Maputo',
+    'Africa/Bujumbura': 'Africa/Maputo',
+    'Africa/Gaborone': 'Africa/Maputo',
+    'Africa/Harare': 'Africa/Maputo',
+    'Africa/Kigali': 'Africa/Maputo',
+    'Africa/Lubumbashi': 'Africa/Maputo',
+    'Africa/Lusaka': 'Africa/Maputo',
+    'Asia/Tel_Aviv': 'Asia/Jerusalem',
+    'Africa/Maseru': 'Africa/Johannesburg',
+    'Africa/Mbabane': 'Africa/Johannesburg',
+    'Asia/Aden': 'Asia/Riyadh',
+    'Asia/Kuwait': 'Asia/Riyadh',
+    'Asia/Istanbul': 'Europe/Istanbul',
+    'Indian/Reunion': 'Asia/Dubai',
+    'Indian/Mahe': 'Asia/Dubai',
+    'Asia/Muscat': 'Asia/Dubai',
+    'Asia/Calcutta': 'Asia/Kolkata',
+    'Asia/Katmandu': 'Asia/Kathmandu',
+    'Asia/Dacca': 'Asia/Dhaka',
+    'Asia/Yangon': 'Asia/Rangoon',
+    'Asia/Phnom_Penh': 'Asia/Bangkok',
+    'Asia/Vientiane': 'Asia/Bangkok',
+    'Indian/Christmas': 'Asia/Bangkok',
+    'Asia/Kuala_Lumpur': 'Asia/Singapore',
+    'Australia/Canberra': 'Australia/Sydney',
+} as const;
+

--- a/packages/timezone-data/src/index.ts
+++ b/packages/timezone-data/src/index.ts
@@ -280,7 +280,7 @@ interface TimezoneDataWithOffset {
     offsetValue: number;
 }
 
-const getGMTOffsetString = (timeZone: string): GMTOffsetData => {
+const getGMTOffset = (timeZone: string): GMTOffsetData => {
     const options: Intl.DateTimeFormatOptions = {
         timeZone,
         timeZoneName: 'shortOffset'
@@ -316,7 +316,7 @@ const labelWithGMTOffset = (label: string, offsetString: string): string => {
 export const timezoneDataWithGMTOffset = (): TimezoneDataWithOffset[] => {
     return timezoneData
         .map(({name, label}) => {
-            const {offsetString, offsetMinutes} = getGMTOffsetString(name);
+            const {offsetString, offsetMinutes} = getGMTOffset(name);
             return {
                 name,
                 label: offsetString ? labelWithGMTOffset(label, offsetString) : label,

--- a/packages/timezone-data/src/index.ts
+++ b/packages/timezone-data/src/index.ts
@@ -280,10 +280,10 @@ interface TimezoneDataWithOffset {
     offsetValue: number;
 }
 
-const getGMTOffset = (timeZone: string): GMTOffsetData => {
+export const getGMTOffset = (timeZone: string): GMTOffsetData => {
     const options: Intl.DateTimeFormatOptions = {
         timeZone,
-        timeZoneName: 'shortOffset'
+        timeZoneName: 'longOffset'
     };
     
     const formatter = new Intl.DateTimeFormat('en-GB', options);
@@ -294,15 +294,16 @@ const getGMTOffset = (timeZone: string): GMTOffsetData => {
         return {offsetString: null, offsetMinutes: 0};
     }
 
-    const match = offsetPart.match(/^GMT([+-])(\d{1,2})(?::(\d{2}))?$/);
+    // Expecting formats like "GMT+05:30" or "GMT-08:00"
+    const match = offsetPart.match(/^GMT([+-])(\d{2}):(\d{2})$/);
     
     if (!match) {
         return {offsetString: offsetPart, offsetMinutes: 0};
     }
 
-    const sign = match[1];
-    const hour = parseInt(match[2], 10);
-    const minute = parseInt(match[3] ?? '0', 10);
+    const [, sign, hourStr, minuteStr] = match;
+    const hour = parseInt(hourStr, 10);
+    const minute = parseInt(minuteStr, 10);
     const totalMinutes = sign === '+' ? (hour * 60 + minute) : -(hour * 60 + minute);
     const offsetString = `GMT ${sign}${hour}:${minute.toString().padStart(2, '0')}`;
     

--- a/packages/timezone-data/src/index.ts
+++ b/packages/timezone-data/src/index.ts
@@ -1,272 +1,329 @@
 const timezoneData: {name: string; label: string}[] = [
     {
         name: 'Pacific/Pago_Pago',
-        label: '(GMT -11:00) Midway Island, Samoa'
+        label: 'Midway Island, Samoa'
     },
     {
         name: 'Pacific/Honolulu',
-        label: '(GMT -10:00) Hawaii'
+        label: 'Hawaii'
     },
     {
         name: 'America/Anchorage',
-        label: '(GMT -9:00) Alaska'
+        label: 'Alaska'
     },
     {
         name: 'America/Tijuana',
-        label: '(GMT -8:00) Chihuahua, La Paz, Mazatlan'
+        label: 'Chihuahua, La Paz, Mazatlan'
     },
     {
         name: 'America/Los_Angeles',
-        label: '(GMT -8:00) Pacific Time (US & Canada); Tijuana'
+        label: 'Pacific Time (US & Canada); Tijuana'
     },
     {
         name: 'America/Phoenix',
-        label: '(GMT -7:00) Arizona'
+        label: 'Arizona'
     },
     {
         name: 'America/Denver',
-        label: '(GMT -7:00) Mountain Time (US & Canada)'
+        label: 'Mountain Time (US & Canada)'
     },
     {
         name: 'America/Costa_Rica',
-        label: '(GMT -6:00) Central America'
+        label: 'Central America'
     },
     {
         name: 'America/Chicago',
-        label: '(GMT -6:00) Central Time (US & Canada)'
+        label: 'Central Time (US & Canada)'
     },
     {
         name: 'America/Mexico_City',
-        label: '(GMT -6:00) Guadalajara, Mexico City, Monterrey'
+        label: 'Guadalajara, Mexico City, Monterrey'
     },
     {
         name: 'America/Regina',
-        label: '(GMT -6:00) Saskatchewan'
+        label: 'Saskatchewan'
     },
     {
         name: 'America/Bogota',
-        label: '(GMT -5:00) Bogota, Lima, Quito'
+        label: 'Bogota, Lima, Quito'
     },
     {
         name: 'America/New_York',
-        label: '(GMT -5:00) Eastern Time (US & Canada)'
+        label: 'Eastern Time (US & Canada)'
     },
     {
         name: 'America/Fort_Wayne',
-        label: '(GMT -5:00) Indiana (East)'
+        label: 'Indiana (East)'
     },
     {
         name: 'America/Caracas',
-        label: '(GMT -4:00) Caracas, La Paz'
+        label: 'Caracas, La Paz'
     },
     {
         name: 'America/Halifax',
-        label: '(GMT -4:00) Atlantic Time (Canada); Greenland'
+        label: 'Atlantic Time (Canada); Greenland'
     },
     {
         name: 'America/Santiago',
-        label: '(GMT -4:00) Santiago'
+        label: 'Santiago'
     },
     {
         name: 'America/St_Johns',
-        label: '(GMT -3:30) Newfoundland'
+        label: 'Newfoundland'
     },
     {
         name: 'America/Argentina/Buenos_Aires',
-        label: '(GMT -3:00) Buenos Aires, Brasilia, Georgetown'
+        label: 'Buenos Aires, Brasilia, Georgetown'
     },
     {
         name: 'America/Noronha',
-        label: '(GMT -2:00) Fernando de Noronha'
+        label: 'Fernando de Noronha'
     },
     {
         name: 'Atlantic/Azores',
-        label: '(GMT -1:00) Azores'
+        label: 'Azores'
     },
     {
         name: 'Atlantic/Cape_Verde',
-        label: '(GMT -1:00) Cape Verde Is.'
+        label: 'Cape Verde Is.'
     },
     {
         name: 'Etc/UTC',
-        label: '(GMT) UTC'
+        label: 'UTC'
     },
     {
         name: 'Africa/Casablanca',
-        label: '(GMT +0:00) Casablanca, Monrovia'
+        label: 'Casablanca, Monrovia'
     },
     {
         name: 'Europe/Dublin',
-        label: '(GMT +0:00) Dublin, Edinburgh, London'
+        label: 'Dublin, Edinburgh, London'
     },
     {
         name: 'Europe/Amsterdam',
-        label: '(GMT +1:00) Amsterdam, Berlin, Rome, Stockholm, Vienna'
+        label: ' Amsterdam, Berlin, Rome, Stockholm, Vienna'
     },
     {
         name: 'Europe/Prague',
-        label: '(GMT +1:00) Belgrade, Bratislava, Budapest, Prague'
+        label: 'Belgrade, Bratislava, Budapest, Prague'
     },
     {
         name: 'Europe/Paris',
-        label: '(GMT +1:00) Brussels, Copenhagen, Madrid, Paris'
+        label: 'Brussels, Copenhagen, Madrid, Paris'
     },
     {
         name: 'Europe/Warsaw',
-        label: '(GMT +1:00) Sarajevo, Skopje, Warsaw, Zagreb'
+        label: 'Sarajevo, Skopje, Warsaw, Zagreb'
     },
     {
         name: 'Africa/Lagos',
-        label: '(GMT +1:00) West Central Africa'
+        label: 'West Central Africa'
     },
     {
         name: 'Europe/Athens',
-        label: '(GMT +2:00) Athens, Beirut, Bucharest'
+        label: 'Athens, Beirut, Bucharest'
     },
     {
         name: 'Africa/Cairo',
-        label: '(GMT +2:00) Cairo, Egypt'
+        label: 'Cairo, Egypt'
     },
     {
         name: 'Africa/Maputo',
-        label: '(GMT +2:00) Harare'
+        label: 'Harare'
     },
     {
         name: 'Europe/Kiev', // Changing name to 'Europe/Kiev', and keeping the UI with Kyiv. Change this once we are passed the moment lib update.
-        label: '(GMT +2:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius'
+        label: 'Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius'
     },
     {
         name: 'Asia/Jerusalem',
-        label: '(GMT +2:00) Jerusalem'
+        label: 'Jerusalem'
     },
     {
         name: 'Africa/Johannesburg',
-        label: '(GMT +2:00) Pretoria'
+        label: 'Pretoria'
     },
     {
         name: 'Asia/Baghdad',
-        label: '(GMT +3:00) Baghdad'
+        label: 'Baghdad'
     },
     {
         name: 'Asia/Riyadh',
-        label: '(GMT +3:00) Kuwait, Nairobi, Riyadh'
+        label: 'Kuwait, Nairobi, Riyadh'
     },
     {
         name: 'Europe/Istanbul',
-        label: '(GMT +3:00) Istanbul, Ankara'
+        label: 'Istanbul, Ankara'
     },
     {
         name: 'Europe/Moscow',
-        label: '(GMT +3:00) Moscow, St. Petersburg, Volgograd'
+        label: 'Moscow, St. Petersburg, Volgograd'
     },
     {
         name: 'Asia/Tehran',
-        label: '(GMT +3:30) Tehran'
+        label: 'Tehran'
     },
     {
         name: 'Asia/Dubai',
-        label: '(GMT +4:00) Abu Dhabi, Muscat'
+        label: 'Abu Dhabi, Muscat'
     },
     {
         name: 'Asia/Baku',
-        label: '(GMT +4:00) Baku, Tbilisi, Yerevan'
+        label: 'Baku, Tbilisi, Yerevan'
     },
     {
         name: 'Asia/Kabul',
-        label: '(GMT +4:30) Kabul'
+        label: 'Kabul'
     },
     {
         name: 'Asia/Karachi',
-        label: '(GMT +5:00) Islamabad, Karachi, Tashkent'
+        label: 'Islamabad, Karachi, Tashkent'
     },
     {
         name: 'Asia/Yekaterinburg',
-        label: '(GMT +5:00) Yekaterinburg'
+        label: 'Yekaterinburg'
     },
     {
         name: 'Asia/Kolkata',
-        label: '(GMT +5:30) Chennai, Calcutta, Mumbai, New Delhi'
+        label: 'Chennai, Kolkata, Mumbai, New Delhi'
     },
     {
         name: 'Asia/Kathmandu',
-        label: '(GMT +5:45) Katmandu'
+        label: 'Katmandu'
     },
     {
         name: 'Asia/Almaty',
-        label: '(GMT +6:00) Almaty, Novosibirsk'
+        label: 'Almaty, Novosibirsk'
     },
     {
         name: 'Asia/Dhaka',
-        label: '(GMT +6:00) Astana, Dhaka, Sri Jayawardenepura'
+        label: 'Astana, Dhaka, Sri Jayawardenepura'
     },
     {
         name: 'Asia/Rangoon',
-        label: '(GMT +6:30) Rangoon'
+        label: 'Rangoon'
     },
     {
         name: 'Asia/Bangkok',
-        label: '(GMT +7:00) Bangkok, Hanoi, Jakarta'
+        label: 'Bangkok, Hanoi, Jakarta'
     },
     {
         name: 'Asia/Krasnoyarsk',
-        label: '(GMT +7:00) Krasnoyarsk'
+        label: 'Krasnoyarsk'
     },
     {
         name: 'Asia/Hong_Kong',
-        label: '(GMT +8:00) Beijing, Chongqing, Hong Kong, Urumqi'
+        label: 'Beijing, Chongqing, Hong Kong, Urumqi'
     },
     {
         name: 'Asia/Irkutsk',
-        label: '(GMT +8:00) Irkutsk, Ulaan Bataar'
+        label: 'Irkutsk, Ulaan Bataar'
     },
     {
         name: 'Asia/Singapore',
-        label: '(GMT +8:00) Kuala Lumpur, Perth, Singapore, Taipei'
+        label: 'Kuala Lumpur, Perth, Singapore, Taipei'
     },
     {
         name: 'Asia/Tokyo',
-        label: '(GMT +9:00) Osaka, Sapporo, Tokyo'
+        label: 'Osaka, Sapporo, Tokyo'
     },
     {
         name: 'Asia/Seoul',
-        label: '(GMT +9:00) Seoul'
+        label: 'Seoul'
     },
     {
         name: 'Asia/Yakutsk',
-        label: '(GMT +9:00) Yakutsk'
+        label: 'Yakutsk'
     },
     {
         name: 'Australia/Adelaide',
-        label: '(GMT +9:30) Adelaide'
+        label: 'Adelaide'
     },
     {
         name: 'Australia/Darwin',
-        label: '(GMT +9:30) Darwin'
+        label: 'Darwin'
     },
     {
         name: 'Australia/Brisbane',
-        label: '(GMT +10:00) Brisbane, Guam, Port Moresby'
+        label: 'Brisbane, Guam, Port Moresby'
     },
     {
         name: 'Australia/Sydney',
-        label: '(GMT +10:00) Canberra, Hobart, Melbourne, Sydney, Vladivostok'
+        label: 'Canberra, Hobart, Melbourne, Sydney, Vladivostok'
     },
     {
         name: 'Asia/Magadan',
-        label: '(GMT +11:00) Magadan, Soloman Is., New Caledonia'
+        label: 'Magadan, Soloman Is., New Caledonia'
     },
     {
         name: 'Pacific/Auckland',
-        label: '(GMT +12:00) Auckland, Wellington'
+        label: 'Auckland, Wellington'
     },
     {
         name: 'Pacific/Fiji',
-        label: '(GMT +12:00) Fiji, Kamchatka, Marshall Is.'
+        label: 'Fiji, Kamchatka, Marshall Is.'
     },
     {
         name: 'Pacific/Kwajalein',
-        label: '(GMT +12:00) International Date Line West'
+        label: 'International Date Line West'
     }
 ];
+
+interface GMTOffsetData {
+    offsetString: string | null;
+    offsetMinutes: number;
+}
+
+interface TimezoneDataWithOffset {
+    name: string;
+    label: string;
+    offsetValue: number;
+}
+
+const getGMTOffsetString = (timeZone: string): GMTOffsetData => {
+    const options: Intl.DateTimeFormatOptions = {
+        timeZone,
+        timeZoneName: 'shortOffset'
+    };
+    
+    const formatter = new Intl.DateTimeFormat('en-GB', options);
+    const parts = formatter.formatToParts(new Date());
+    const offsetPart = parts.find(part => part.type === 'timeZoneName')?.value;
+
+    if (!offsetPart) {
+        return {offsetString: null, offsetMinutes: 0};
+    }
+
+    const match = offsetPart.match(/^GMT([+-])(\d{1,2})(?::(\d{2}))?$/);
+    
+    if (!match) {
+        return {offsetString: offsetPart, offsetMinutes: 0};
+    }
+
+    const sign = match[1];
+    const hour = parseInt(match[2], 10);
+    const minute = parseInt(match[3] ?? '0', 10);
+    const totalMinutes = sign === '+' ? (hour * 60 + minute) : -(hour * 60 + minute);
+    const offsetString = `GMT ${sign}${hour}:${minute.toString().padStart(2, '0')}`;
+    
+    return {offsetString, offsetMinutes: totalMinutes};
+};
+
+const labelWithGMTOffset = (label: string, offsetString: string): string => {
+    return '(' + offsetString + ') ' + label;
+};
+
+export const timezoneDataWithGMTOffset = (): TimezoneDataWithOffset[] => {
+    return timezoneData
+        .map(({name, label}) => {
+            const {offsetString, offsetMinutes} = getGMTOffsetString(name);
+            return {
+                name,
+                label: offsetString ? labelWithGMTOffset(label, offsetString) : label,
+                offsetValue: offsetMinutes
+            };
+        })
+        .sort((a, b) => a.offsetValue - b.offsetValue);
+};
 
 export default timezoneData;

--- a/packages/timezone-data/src/index.ts
+++ b/packages/timezone-data/src/index.ts
@@ -1,273 +1,4 @@
-const timezoneData: {name: string; label: string}[] = [
-    {
-        name: 'Pacific/Pago_Pago',
-        label: 'Midway Island, Samoa'
-    },
-    {
-        name: 'Pacific/Honolulu',
-        label: 'Hawaii'
-    },
-    {
-        name: 'America/Anchorage',
-        label: 'Alaska'
-    },
-    {
-        name: 'America/Tijuana',
-        label: 'Chihuahua, La Paz, Mazatlan'
-    },
-    {
-        name: 'America/Los_Angeles',
-        label: 'Pacific Time (US & Canada); Tijuana'
-    },
-    {
-        name: 'America/Phoenix',
-        label: 'Arizona'
-    },
-    {
-        name: 'America/Denver',
-        label: 'Mountain Time (US & Canada)'
-    },
-    {
-        name: 'America/Costa_Rica',
-        label: 'Central America'
-    },
-    {
-        name: 'America/Chicago',
-        label: 'Central Time (US & Canada)'
-    },
-    {
-        name: 'America/Mexico_City',
-        label: 'Guadalajara, Mexico City, Monterrey'
-    },
-    {
-        name: 'America/Regina',
-        label: 'Saskatchewan'
-    },
-    {
-        name: 'America/Bogota',
-        label: 'Bogota, Lima, Quito'
-    },
-    {
-        name: 'America/New_York',
-        label: 'Eastern Time (US & Canada)'
-    },
-    {
-        name: 'America/Fort_Wayne',
-        label: 'Indiana (East)'
-    },
-    {
-        name: 'America/Caracas',
-        label: 'Caracas, La Paz'
-    },
-    {
-        name: 'America/Halifax',
-        label: 'Atlantic Time (Canada); Greenland'
-    },
-    {
-        name: 'America/Santiago',
-        label: 'Santiago'
-    },
-    {
-        name: 'America/St_Johns',
-        label: 'Newfoundland'
-    },
-    {
-        name: 'America/Argentina/Buenos_Aires',
-        label: 'Buenos Aires, Brasilia, Georgetown'
-    },
-    {
-        name: 'America/Noronha',
-        label: 'Fernando de Noronha'
-    },
-    {
-        name: 'Atlantic/Azores',
-        label: 'Azores'
-    },
-    {
-        name: 'Atlantic/Cape_Verde',
-        label: 'Cape Verde Is.'
-    },
-    {
-        name: 'Etc/UTC',
-        label: 'UTC'
-    },
-    {
-        name: 'Africa/Casablanca',
-        label: 'Casablanca, Monrovia'
-    },
-    {
-        name: 'Europe/Dublin',
-        label: 'Dublin, Edinburgh, London'
-    },
-    {
-        name: 'Europe/Amsterdam',
-        label: ' Amsterdam, Berlin, Rome, Stockholm, Vienna'
-    },
-    {
-        name: 'Europe/Prague',
-        label: 'Belgrade, Bratislava, Budapest, Prague'
-    },
-    {
-        name: 'Europe/Paris',
-        label: 'Brussels, Copenhagen, Madrid, Paris'
-    },
-    {
-        name: 'Europe/Warsaw',
-        label: 'Sarajevo, Skopje, Warsaw, Zagreb'
-    },
-    {
-        name: 'Africa/Lagos',
-        label: 'West Central Africa'
-    },
-    {
-        name: 'Europe/Athens',
-        label: 'Athens, Beirut, Bucharest'
-    },
-    {
-        name: 'Africa/Cairo',
-        label: 'Cairo, Egypt'
-    },
-    {
-        name: 'Africa/Maputo',
-        label: 'Harare'
-    },
-    {
-        name: 'Europe/Kiev', // Changing name to 'Europe/Kiev', and keeping the UI with Kyiv. Change this once we are passed the moment lib update.
-        label: 'Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius'
-    },
-    {
-        name: 'Asia/Jerusalem',
-        label: 'Jerusalem'
-    },
-    {
-        name: 'Africa/Johannesburg',
-        label: 'Pretoria'
-    },
-    {
-        name: 'Asia/Baghdad',
-        label: 'Baghdad'
-    },
-    {
-        name: 'Asia/Riyadh',
-        label: 'Kuwait, Nairobi, Riyadh'
-    },
-    {
-        name: 'Europe/Istanbul',
-        label: 'Istanbul, Ankara'
-    },
-    {
-        name: 'Europe/Moscow',
-        label: 'Moscow, St. Petersburg, Volgograd'
-    },
-    {
-        name: 'Asia/Tehran',
-        label: 'Tehran'
-    },
-    {
-        name: 'Asia/Dubai',
-        label: 'Abu Dhabi, Muscat'
-    },
-    {
-        name: 'Asia/Baku',
-        label: 'Baku, Tbilisi, Yerevan'
-    },
-    {
-        name: 'Asia/Kabul',
-        label: 'Kabul'
-    },
-    {
-        name: 'Asia/Karachi',
-        label: 'Islamabad, Karachi, Tashkent'
-    },
-    {
-        name: 'Asia/Yekaterinburg',
-        label: 'Yekaterinburg'
-    },
-    {
-        name: 'Asia/Kolkata',
-        label: 'Chennai, Kolkata, Mumbai, New Delhi'
-    },
-    {
-        name: 'Asia/Kathmandu',
-        label: 'Katmandu'
-    },
-    {
-        name: 'Asia/Almaty',
-        label: 'Almaty, Novosibirsk'
-    },
-    {
-        name: 'Asia/Dhaka',
-        label: 'Astana, Dhaka, Sri Jayawardenepura'
-    },
-    {
-        name: 'Asia/Rangoon',
-        label: 'Rangoon'
-    },
-    {
-        name: 'Asia/Bangkok',
-        label: 'Bangkok, Hanoi, Jakarta'
-    },
-    {
-        name: 'Asia/Krasnoyarsk',
-        label: 'Krasnoyarsk'
-    },
-    {
-        name: 'Asia/Hong_Kong',
-        label: 'Beijing, Chongqing, Hong Kong, Urumqi'
-    },
-    {
-        name: 'Asia/Irkutsk',
-        label: 'Irkutsk, Ulaan Bataar'
-    },
-    {
-        name: 'Asia/Singapore',
-        label: 'Kuala Lumpur, Perth, Singapore, Taipei'
-    },
-    {
-        name: 'Asia/Tokyo',
-        label: 'Osaka, Sapporo, Tokyo'
-    },
-    {
-        name: 'Asia/Seoul',
-        label: 'Seoul'
-    },
-    {
-        name: 'Asia/Yakutsk',
-        label: 'Yakutsk'
-    },
-    {
-        name: 'Australia/Adelaide',
-        label: 'Adelaide'
-    },
-    {
-        name: 'Australia/Darwin',
-        label: 'Darwin'
-    },
-    {
-        name: 'Australia/Brisbane',
-        label: 'Brisbane, Guam, Port Moresby'
-    },
-    {
-        name: 'Australia/Sydney',
-        label: 'Canberra, Hobart, Melbourne, Sydney, Vladivostok'
-    },
-    {
-        name: 'Asia/Magadan',
-        label: 'Magadan, Soloman Is., New Caledonia'
-    },
-    {
-        name: 'Pacific/Auckland',
-        label: 'Auckland, Wellington'
-    },
-    {
-        name: 'Pacific/Fiji',
-        label: 'Fiji, Kamchatka, Marshall Is.'
-    },
-    {
-        name: 'Pacific/Kwajalein',
-        label: 'International Date Line West'
-    }
-];
+import {timezoneData, aliasTimezones} from './data';
 
 interface GMTOffsetData {
     offsetString: string | null;
@@ -277,7 +8,7 @@ interface GMTOffsetData {
 interface TimezoneDataWithOffset {
     name: string;
     label: string;
-    offsetValue: number;
+    offsetMinutes: number;
 }
 
 export const getGMTOffset = (timeZone: string): GMTOffsetData => {
@@ -321,10 +52,22 @@ export const timezoneDataWithGMTOffset = (): TimezoneDataWithOffset[] => {
             return {
                 name,
                 label: offsetString ? labelWithGMTOffset(label, offsetString) : label,
-                offsetValue: offsetMinutes
+                offsetMinutes
             };
         })
-        .sort((a, b) => a.offsetValue - b.offsetValue);
+        .sort((a, b) => a.offsetMinutes - b.offsetMinutes);
+};
+
+export const maybeFetchAliasTimezone = (timezone: string): string => {
+    if (hasAliasTimezone(timezone)) {
+        return aliasTimezones[ timezone ];
+    }
+
+    return timezone;
+};
+
+const hasAliasTimezone = (timezone: string): timezone is keyof typeof aliasTimezones => {
+    return timezone in aliasTimezones;
 };
 
 export default timezoneData;

--- a/packages/timezone-data/tsconfig.json
+++ b/packages/timezone-data/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2016",
+    "target": "es2020",
     "module": "ESNext",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
### Description:

This PR introduces a curated alias mapping for timezone identifiers to support older or deprecated IANA names. The alias list is derived from IANA's [backward compatibility database](https://data.iana.org/time-zones/tzdb/backward) and manually mapped to match the timezone options used in Ghost’s dropdown selector.

### Why this is needed

This alias mapping is required to support auto-selection of timezones during new account creation, as implemented in [Ghost PR #1](https://github.com/niranjan-uma-shankar/Ghost/pull/1).

Some browsers may return outdated IANA timezone identifiers. For example, setting your macOS system timezone to Kolkata and running the following in the browser:

```
Intl.DateTimeFormat().resolvedOptions().timeZone
```

... will return:

```
Asia/Calcutta
```

However, `Asia/Calcutta` is a legacy identifier; the modern equivalent in IANA is `Asia/Kolkata`.

Ghost’s timezone dropdown uses the newer identifiers. Without this alias mapping, automatic matching fails for users in regions where legacy identifiers are still returned by the browser.

### What this fixes

This mapping ensures that:

* Legacy IANA identifiers (e.g., `Asia/Calcutta`) are correctly recognized.
* The blog timezone auto-selection logic can consistently resolve browser-reported timezones.
* Dropdown values in Ghost remain consistent with the IANA standard without forcing updates on users or browsers.